### PR TITLE
Fix a bug that caused the output directory cannot be created

### DIFF
--- a/source/build.py
+++ b/source/build.py
@@ -6,9 +6,9 @@ root=os.getcwd()
 source=path.join(root,"ttx")
 output=path.join(root,"output")
 if not path.exists(path.join(output,"otf")):
-  os.mkdir(path.join(output,"otf"))
+  os.makedirs(path.join(output,"otf"))
 if not path.exists(path.join(output,"ttf")):
-  os.mkdir(path.join(output,"ttf"))
+  os.makedirs(path.join(output,"ttf"))
 print("=== build start ===")
 for f in os.listdir(source):
   print(f)


### PR DESCRIPTION
运行`python build.py` 直接创建`otf` 和`ttf`目录时，由于上级`output`目录不存在会报错，所以将`mkdir` 替换为了`makedirs`，允许递归的创建目录。