### PR TITLE
docs: update Arch Linux install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Inspired by [Source Code Pro](https://github.com/adobe-fonts/source-code-pro), [
 | Platform   | Command                                                                     |
 | :--------- | :-------------------------------------------------------------------------- |
 | macOS      | `brew tap homebrew/cask-fonts && brew install font-maple`                   |
-| Arch Linux | `sudo pacman -S ttf-maple`                                                  |
+| Arch Linux | `paru -S ttf-maple-lastest`                                                 |
 | Others     | Download in [releases](https://github.com/subframe7536/Maple-font/releases) |
 
 


### PR DESCRIPTION
The old one's version is still 5.3