### PR TITLE
Use MacOS FontForge's embedded Python if available

### DIFF
--- a/source/build.py
+++ b/source/build.py
@@ -122,7 +122,7 @@ def generate_nerd_font(f: str):
 
     system = platform.uname()[0]
     script = path.join(
-        root, f"generate-nerdfont.{'bat' if 'Windows' in system else 'sh'}"
+        root, f"generate-nerdfont{'-mac' if 'Darwin' in system else ''}.{'bat' if 'Windows' in system else 'sh'}"
     )
 
     make_sure_eol(script)

--- a/source/generate-nerdfont-mac.sh
+++ b/source/generate-nerdfont-mac.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -xeuo
+
+python=$(which python3)
+output_dir="../output/NF"
+font_dir="../output/ttf"
+ff_app_dir="/Applications/FontForge.app"
+
+if [ -d "${ff_app_dir}" ]; then
+    python="${ff_app_dir}/Contents/MacOS/FFPython"
+fi
+
+if [ "$3" = "1" ]; then
+    font_dir="${font_dir}-autohint"
+fi
+
+if [ ! -d "${font_dir}" ]; then
+    echo "Font directory does not exist: ${font_dir}"
+    exit 1
+fi
+
+# full args: https://github.com/ryanoasis/nerd-fonts#font-patcher
+args="-l -c --careful"
+if [ "$2" = "1" ]; then
+    args="${args} -s"
+fi
+
+font_name="$1"
+target_font_path="${font_dir}/${font_name}.ttf"
+
+if [ ! -f "${target_font_path}" ]; then
+    echo "Font file does not exist: ${target_font_path}"
+    exit 1
+fi
+
+eval "${python} ./FontPatcher/font-patcher ${args} --outputdir ${output_dir} ${target_font_path}"


### PR DESCRIPTION
Hello, thanks for the great font!

I'm building using mac os, and I noticed that FontPatcher uses FontForge's python modules: `fontforge` and `psMat`.

This is just an expansion of [this PR](https://github.com/subframe7536/maple-font/pull/119) which uses FontForge's internal python which happens to link those two required modules. If there's no FontForge installed, it just uses default system's python.