### PR TITLE
Update README to use correct install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Inspired by [Source Code Pro](https://github.com/adobe-fonts/source-code-pro), [
 
 | Platform   | Command                                                                     |
 | :--------- | :-------------------------------------------------------------------------- |
-| macOS      | `brew tap homebrew/cask-fonts && brew install font-maple`                   |
+| macOS      | `brew install --cask font-maple`                                            |
 | Arch Linux | `paru -S ttf-maple`                                                         |
 | Others     | Download in [releases](https://github.com/subframe7536/Maple-font/releases) |
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -48,7 +48,7 @@
 
 | 平台       | 命令                                                                                                                                     |
 | :--------- | :--------------------------------------------------------------------------------------------------------------------------------------- |
-| macOS      | ` brew tap homebrew/cask-fonts && brew install font-maple`                                                                               |
+| macOS      | `brew install --cask font-maple`                                                                                                         |
 | Arch Linux | `paru -S ttf-maple-latest`                                                                                                               |
 | Others     | 从 [releases](https://github.com/subframe7536/Maple-font/releases) 中下载安装，[国内地址](https://gitee.com/subframe7536/Maple/releases) |
 


### PR DESCRIPTION
The homebrew font tap has been deprecated and merged into homebrew/cask, so that should be used instead.