### PR TITLE
Fix pylint warning `unspecified-encoding`

### DIFF
--- a/source/build.py
+++ b/source/build.py
@@ -313,7 +313,7 @@ def compress_folder(source_folder_path, target_path):
 
 
 # write config to output path
-with open(path.join(output_path, "build-config.json"), "w") as config_file:
+with open(path.join(output_path, "build-config.json"), "w", encoding="utf-8") as config_file:
     config_file.write(conf)
 
 if release_mode:
@@ -334,7 +334,7 @@ if release_mode:
         print("archieve:", f)
 
     # write sha1
-    with open(path.join(output_path, "release", "sha1.json"), "w") as hash_file:
+    with open(path.join(output_path, "release", "sha1.json"), "w", encoding="utf-8") as hash_file:
         hash_file.write(json.dumps(hash_map, indent=4))
 
     # copy woff


### PR DESCRIPTION
Changes Made:

- Applied automated fixes for the pylint warning unspecified-encoding.
"It is better to specify an encoding when opening documents. Using the system default implicitly can create problems on other operating systems. See [https://peps.python.org/pep-0597/](https://peps.python.org/pep-0597/)"

Note:
This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.