### PR TITLE
Remove `--forgive`

### DIFF
--- a/build.py
+++ b/build.py
@@ -771,7 +771,7 @@ def build_mono(f: str, font_config: FontConfig, build_option: BuildOption):
     verify_glyph_width(
         font=font,
         expect_widths=font_config.get_valid_glyph_width_list(),
-        name=postscript_name,
+        file_name=postscript_name,
     )
 
     remove(source_path)
@@ -890,7 +890,7 @@ def build_nf(
     verify_glyph_width(
         font=nf_font,
         expect_widths=font_config.get_valid_glyph_width_list(),
-        name=postscript_name,
+        file_name=postscript_name,
     )
 
     target_path = joinPaths(
@@ -979,7 +979,7 @@ def build_cn(f: str, font_config: FontConfig, build_option: BuildOption):
     verify_glyph_width(
         font=cn_font,
         expect_widths=font_config.get_valid_glyph_width_list(True),
-        name=postscript_name,
+        file_name=postscript_name,
     )
     target_path = joinPaths(
         build_option.output_cn,
@@ -1098,7 +1098,7 @@ def main():
             verify_glyph_width(
                 font=font,
                 expect_widths=font_config.get_valid_glyph_width_list(),
-                name=basename,
+                file_name=basename,
             )
 
             add_gasp(font)

--- a/source/py/utils.py
+++ b/source/py/utils.py
@@ -191,7 +191,7 @@ def match_unicode_names(file_path: str) -> dict[str, str]:
 
 
 # https://github.com/subframe7536/maple-font/issues/314
-def verify_glyph_width(font: TTFont, expect_widths: list[int], forgive: bool):
+def verify_glyph_width(font: TTFont, expect_widths: list[int], name: str = None):
     print("Verify glyph width...")
     result: tuple[str, int] = []
     for name in font.getGlyphNames():
@@ -204,12 +204,9 @@ def verify_glyph_width(font: TTFont, expect_widths: list[int], forgive: bool):
         for item in result:
             print(f"{item[0]}  =>  {item[1]}")
 
-        if forgive:
-            print("❗Forgive it")
-        else:
-            raise Exception(
-                f"The font may contain glyphs that width is not in {expect_widths}, which may broke monospace rule."
-            )
+        raise Exception(
+            f"{name or 'The font'} may contain glyphs that width is not in {expect_widths}, which may broke monospace rule."
+        )
 
 
 def compress_folder(

--- a/source/py/utils.py
+++ b/source/py/utils.py
@@ -191,7 +191,7 @@ def match_unicode_names(file_path: str) -> dict[str, str]:
 
 
 # https://github.com/subframe7536/maple-font/issues/314
-def verify_glyph_width(font: TTFont, expect_widths: list[int], name: str = None):
+def verify_glyph_width(font: TTFont, expect_widths: list[int], file_name: str = None):
     print("Verify glyph width...")
     result: tuple[str, int] = []
     for name in font.getGlyphNames():
@@ -205,7 +205,7 @@ def verify_glyph_width(font: TTFont, expect_widths: list[int], name: str = None)
             print(f"{item[0]}  =>  {item[1]}")
 
         raise Exception(
-            f"{name or 'The font'} may contain glyphs that width is not in {expect_widths}, which may broke monospace rule."
+            f"{file_name or 'The font'} may contain glyphs that width is not in {expect_widths}, which may broke monospace rule."
         )
 
 


### PR DESCRIPTION
The issue is reported in #339 .

The `--forgive` flag is a temporary solution that used for skipping glyph width verification. But the core problem is that **italic** base fonts in `cn-base-static.zip` has unused wrong glyph width. In my local machine, the verification is called after all fonts built and *only verify the first file* (always be regular style), but in CI the italic style is choosen, so it breaks the CI. This should be resolved before 7.0 stable.

After the fix, `--forgive` will be removed and this PR will be merged.

In this PR, the verifications are called across all styles, make sure all files in different unicode sets are verified. Also, the `--forgive` flag will be removed.