### PR TITLE
点星历史支持暗黑主题

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,7 +753,13 @@ or sponser me through [Afdian](https://afdian.com/a/subframe7536)
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=subframe7536/maple-font&type=Date)](https://www.star-history.com/#subframe7536/maple-font&Date)
+<a href="https://www.star-history.com/#subframe7536/maple-font&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=subframe7536/maple-font&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=subframe7536/maple-font&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=subframe7536/maple-font&type=date&legend=top-left" />
+ </picture>
+</a>
 
 ## License
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -734,7 +734,13 @@ Build Options:
 
 ## 点星
 
-[![Star History Chart](https://api.star-history.com/svg?repos=subframe7536/maple-font&type=Date)](https://www.star-history.com/#subframe7536/maple-font&Date)
+<a href="https://www.star-history.com/#subframe7536/maple-font&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=subframe7536/maple-font&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=subframe7536/maple-font&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=subframe7536/maple-font&type=date&legend=top-left" />
+ </picture>
+</a>
 
 ## 许可
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -731,7 +731,13 @@ Build Options:
 
 ## スター履歴
 
-[![Star History Chart](https://api.star-history.com/svg?repos=subframe7536/maple-font&type=Date)](https://www.star-history.com/#subframe7536/maple-font&Date)
+<a href="https://www.star-history.com/#subframe7536/maple-font&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=subframe7536/maple-font&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=subframe7536/maple-font&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=subframe7536/maple-font&type=date&legend=top-left" />
+ </picture>
+</a>
 
 ## ライセンス
 


### PR DESCRIPTION
点星历史的图表颜色可以根据 GitHub 是亮色主题还是暗色主题自动切换, 避免闪光弹 🤣 