### PR TITLE
feat(cn): 新增 scale-punctuation-factor 选项，支持CJK字形与全角标点字形使用不同的缩放倍率

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,9 +705,9 @@ Feature Options:
   --cn-scale-factor CN_SCALE_FACTOR
                         Scale factor for CN / JP glyphs. Format: <factor> or
                         <width_factor>,<height_factor> (e.g. 1.1 or 1.2,1.1)
-  --cn-scale-skip-punctuation
-                        Skip scaling for fullwidth punctuation glyphs when using
-                        --cn-scale-factor
+  --cn-scale-punctuation-factor CN_SCALE_PUNCTUATION_FACTOR
+                        Scale factor for fullwidth punctuation glyphs. Format:
+                        <factor> or <width_factor>,<height_factor> (e.g. 1.0)
 
 Build Options:
   --nf, --nerd-font     Build Nerd-Font version (default)

--- a/README.md
+++ b/README.md
@@ -705,6 +705,9 @@ Feature Options:
   --cn-scale-factor CN_SCALE_FACTOR
                         Scale factor for CN / JP glyphs. Format: <factor> or
                         <width_factor>,<height_factor> (e.g. 1.1 or 1.2,1.1)
+  --cn-scale-skip-punctuation
+                        Skip scaling for fullwidth punctuation glyphs when using
+                        --cn-scale-factor
 
 Build Options:
   --nf, --nerd-font     Build Nerd-Font version (default)

--- a/README_CN.md
+++ b/README_CN.md
@@ -711,8 +711,9 @@ Feature Options:
   --cn-scale-factor CN_SCALE_FACTOR
                         中文/日文字形的缩放因子。格式：<因子> 或
                         <宽度因子>,<高度因子> (例如 1.1 或 1.2,1.1)
-  --cn-scale-skip-punctuation
-                        使用 --cn-scale-factor 时跳过全角标点符号的缩放
+  --cn-scale-punctuation-factor CN_SCALE_PUNCTUATION_FACTOR
+                        全角标点符号的缩放因子。格式：<因子> 或
+                        <宽度因子>,<高度因子> (例如 1.0)
 
 Build Options:
   --nf, --nerd-font     构建 Nerd-Font 版本（默认）

--- a/README_CN.md
+++ b/README_CN.md
@@ -711,6 +711,8 @@ Feature Options:
   --cn-scale-factor CN_SCALE_FACTOR
                         中文/日文字形的缩放因子。格式：<因子> 或
                         <宽度因子>,<高度因子> (例如 1.1 或 1.2,1.1)
+  --cn-scale-skip-punctuation
+                        使用 --cn-scale-factor 时跳过全角标点符号的缩放
 
 Build Options:
   --nf, --nerd-font     构建 Nerd-Font 版本（默认）

--- a/README_JA.md
+++ b/README_JA.md
@@ -708,6 +708,9 @@ Feature Options:
   --cn-scale-factor CN_SCALE_FACTOR
                         中国語/日本語グリフのスケール係数。形式：<係数> または
                         <幅の係数>,<高さの係数> (例：1.1 または 1.2,1.1)
+  --cn-scale-skip-punctuation
+                        --cn-scale-factor 使用時に全角句読点グリフのスケーリングを
+                        スキップする
 
 Build Options:
   --nf, --nerd-font     Nerd-Fontバージョンをビルド（デフォルト）

--- a/README_JA.md
+++ b/README_JA.md
@@ -708,9 +708,9 @@ Feature Options:
   --cn-scale-factor CN_SCALE_FACTOR
                         中国語/日本語グリフのスケール係数。形式：<係数> または
                         <幅の係数>,<高さの係数> (例：1.1 または 1.2,1.1)
-  --cn-scale-skip-punctuation
-                        --cn-scale-factor 使用時に全角句読点グリフのスケーリングを
-                        スキップする
+  --cn-scale-punctuation-factor CN_SCALE_PUNCTUATION_FACTOR
+                        全角句読点グリフのスケール係数。形式：<係数> または
+                        <幅の係数>,<高さの係数> (例：1.0)
 
 Build Options:
   --nf, --nerd-font     Nerd-Fontバージョンをビルド（デフォルト）

--- a/build.py
+++ b/build.py
@@ -228,9 +228,9 @@ def parse_args(args: list[str] | None = None):
         help="Scale factor for CN / JP glyphs. Format: <factor> or <width_factor>,<height_factor> (e.g. 1.1 or 1.2,1.1)",
     )
     feature_group.add_argument(
-        "--cn-scale-skip-punctuation",
-        action="store_true",
-        help="Skip scaling for fullwidth punctuation glyphs when using --cn-scale-factor",
+        "--cn-scale-punctuation-factor",
+        type=parse_scale_factor,
+        help="Scale factor for fullwidth punctuation glyphs. Format: <factor> or <width_factor>,<height_factor> (e.g. 1.0 or 1.0,1.0)",
     )
 
     build_group = parser.add_argument_group("Build Options")
@@ -404,8 +404,8 @@ class FontConfig:
             "use_static_base_font": True,  # Deprecated. Always `True`
             # scale factor for CN glyphs
             "scale_factor": (1.0, 1.0),
-            # whether to skip scaling for fullwidth punctuation glyphs
-            "scale_skip_punctuation": False,
+            # scale factor for fullwidth punctuation glyphs (None means use scale_factor)
+            "scale_punctuation_factor": None,
         }
         self.glyph_width = 600
         self.glyph_width_cn_narrow = 1000
@@ -534,8 +534,10 @@ class FontConfig:
         if isinstance(self.cn["scale_factor"], (float, list)):
             self.cn["scale_factor"] = parse_scale_factor(self.cn["scale_factor"])
 
-        if args.cn_scale_skip_punctuation:
-            self.cn["scale_skip_punctuation"] = True
+        if args.cn_scale_punctuation_factor:
+            self.cn["scale_punctuation_factor"] = args.cn_scale_punctuation_factor
+        if isinstance(self.cn["scale_punctuation_factor"], (float, list)):
+            self.cn["scale_punctuation_factor"] = parse_scale_factor(self.cn["scale_punctuation_factor"])
 
     def _apply_build_options(self, args):
         """Apply general build options."""
@@ -1397,22 +1399,27 @@ def build_cn(f: str, font_config: FontConfig, build_option: BuildOption):
         else:
             scale_factor = (1.0, 1.0)
 
+        punctuation_scale_factor = font_config.cn["scale_punctuation_factor"]
+        if punctuation_scale_factor:
+            print(f"Scale punctuation glyph to ({punctuation_scale_factor[0]}x, {punctuation_scale_factor[1]}x)")
+
         change_glyph_width_or_scale(
             font=cn_font,
             match_width=match_width,
             target_width=target_width,
             scale_factor=scale_factor,
             special_names=["ellipsis.full"],
-            skip_punctuation=font_config.cn["scale_skip_punctuation"],
+            punctuation_scale_factor=punctuation_scale_factor,
         )
     elif font_config.get_width_name():
+        punctuation_scale_factor = font_config.cn["scale_punctuation_factor"]
         change_glyph_width_or_scale(
             font=cn_font,
             match_width=2 * font_config.glyph_width,
             target_width=2 * font_config.get_target_width(),
             scale_factor=(1.0, 1.0),
             special_names=["ellipsis.full"],
-            skip_punctuation=font_config.cn["scale_skip_punctuation"],
+            punctuation_scale_factor=punctuation_scale_factor,
         )
 
     # https://github.com/subframe7536/maple-font/issues/239

--- a/build.py
+++ b/build.py
@@ -227,6 +227,11 @@ def parse_args(args: list[str] | None = None):
         type=parse_scale_factor,
         help="Scale factor for CN / JP glyphs. Format: <factor> or <width_factor>,<height_factor> (e.g. 1.1 or 1.2,1.1)",
     )
+    feature_group.add_argument(
+        "--cn-scale-skip-punctuation",
+        action="store_true",
+        help="Skip scaling for fullwidth punctuation glyphs when using --cn-scale-factor",
+    )
 
     build_group = parser.add_argument_group("Build Options")
     nf_group = build_group.add_mutually_exclusive_group()
@@ -399,6 +404,8 @@ class FontConfig:
             "use_static_base_font": True,  # Deprecated. Always `True`
             # scale factor for CN glyphs
             "scale_factor": (1.0, 1.0),
+            # whether to skip scaling for fullwidth punctuation glyphs
+            "scale_skip_punctuation": False,
         }
         self.glyph_width = 600
         self.glyph_width_cn_narrow = 1000
@@ -526,6 +533,9 @@ class FontConfig:
             self.cn["scale_factor"] = args.cn_scale_factor
         if isinstance(self.cn["scale_factor"], (float, list)):
             self.cn["scale_factor"] = parse_scale_factor(self.cn["scale_factor"])
+
+        if args.cn_scale_skip_punctuation:
+            self.cn["scale_skip_punctuation"] = True
 
     def _apply_build_options(self, args):
         """Apply general build options."""
@@ -1393,6 +1403,7 @@ def build_cn(f: str, font_config: FontConfig, build_option: BuildOption):
             target_width=target_width,
             scale_factor=scale_factor,
             special_names=["ellipsis.full"],
+            skip_punctuation=font_config.cn["scale_skip_punctuation"],
         )
     elif font_config.get_width_name():
         change_glyph_width_or_scale(
@@ -1401,6 +1412,7 @@ def build_cn(f: str, font_config: FontConfig, build_option: BuildOption):
             target_width=2 * font_config.get_target_width(),
             scale_factor=(1.0, 1.0),
             special_names=["ellipsis.full"],
+            skip_punctuation=font_config.cn["scale_skip_punctuation"],
         )
 
     # https://github.com/subframe7536/maple-font/issues/239

--- a/build.py
+++ b/build.py
@@ -1377,7 +1377,9 @@ def build_cn(f: str, font_config: FontConfig, build_option: BuildOption):
         if font_config.cn["scale_factor"] != (1.0, 1.0)
         else None
     )
-    if target_width or scale_factor:
+    scale_punctuation_factor: tuple[float, float] | None = font_config.cn["scale_punctuation_factor"]
+
+    if target_width or scale_factor or scale_punctuation_factor:
         match_width = 2 * font_config.glyph_width
 
         # Change glyph width and keep monospace identifier will cause
@@ -1399,27 +1401,29 @@ def build_cn(f: str, font_config: FontConfig, build_option: BuildOption):
         else:
             scale_factor = (1.0, 1.0)
 
-        punctuation_scale_factor = font_config.cn["scale_punctuation_factor"]
-        if punctuation_scale_factor:
-            print(f"Scale punctuation glyph to ({punctuation_scale_factor[0]}x, {punctuation_scale_factor[1]}x)")
+        if scale_punctuation_factor:
+            print(
+                f"Scale CN punctuation glyph to ({scale_punctuation_factor[0]}x, {scale_punctuation_factor[1]}x)"
+            )
+        else:
+            scale_punctuation_factor = scale_factor
 
         change_glyph_width_or_scale(
             font=cn_font,
             match_width=match_width,
             target_width=target_width,
             scale_factor=scale_factor,
+            scale_punctuation_factor=scale_punctuation_factor,
             special_names=["ellipsis.full"],
-            punctuation_scale_factor=punctuation_scale_factor,
         )
     elif font_config.get_width_name():
-        punctuation_scale_factor = font_config.cn["scale_punctuation_factor"]
         change_glyph_width_or_scale(
             font=cn_font,
             match_width=2 * font_config.glyph_width,
             target_width=2 * font_config.get_target_width(),
             scale_factor=(1.0, 1.0),
+            scale_punctuation_factor=(1.0, 1.0),
             special_names=["ellipsis.full"],
-            punctuation_scale_factor=punctuation_scale_factor,
         )
 
     # https://github.com/subframe7536/maple-font/issues/239

--- a/config.json
+++ b/config.json
@@ -89,6 +89,6 @@
     "use_hinted": false,
     "use_static_base_font": true,
     "scale_factor": 1.0,
-    "scale_skip_punctuation": false
+    "scale_punctuation_factor": 1.0
   }
 }

--- a/config.json
+++ b/config.json
@@ -88,6 +88,7 @@
     "narrow": false,
     "use_hinted": false,
     "use_static_base_font": true,
-    "scale_factor": 1.0
+    "scale_factor": 1.0,
+    "scale_skip_punctuation": false
   }
 }

--- a/source/py/transform.py
+++ b/source/py/transform.py
@@ -3,6 +3,8 @@ from typing import Any, Tuple, List
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates, Glyph
 
+from source.py.utils import FULLWIDTH_PUNCTUATION_NAMES
+
 # Type aliases
 Coordinate = Tuple[float, float]
 
@@ -232,6 +234,7 @@ def change_glyph_width_or_scale(
     target_width: int,
     scale_factor: tuple[float, float],
     special_names: list[str] = [],
+    skip_punctuation: bool = False,
 ):
     """
     Adjusts the width or scales the glyphs in a font based on the specified parameters.
@@ -248,18 +251,29 @@ def change_glyph_width_or_scale(
             width and height (scale_w, scale_h).
         special_names (list[str], optional): A list of glyph names that require special
             handling instead of trim whitespace only. Defaults to an empty list.
+        skip_punctuation (bool, optional): Whether to skip scaling for fullwidth
+            punctuation glyphs. These glyphs will only be centered, not scaled.
+            Defaults to True.
 
     Notes:
         - Glyphs with a width that does not match `match_width` are skipped.
         - Glyphs with zero contours are only updated in the horizontal metrics.
         - The scaling and translation are applied to the glyph coordinates, and the
           bounding box values are recalculated.
+        - When skip_punctuation is True, fullwidth punctuation glyphs (quotes, ellipsis,
+          em dash, CJK punctuation, etc.) are not scaled, only centered.
     """
     font["hhea"].advanceWidthMax = target_width  # type: ignore
     glyf: Any = font["glyf"]
     hmtx: Any = font["hmtx"]
     factor = target_width / match_width
+
+    # Track statistics
+    scaled_count = 0
+    skipped_punctuation_count = 0
+
     for glyph_name in font.getGlyphOrder():
+        # Handle special names (legacy behavior)
         if glyph_name in special_names:
             _change_glyph_width(
                 glyf=glyf,
@@ -280,6 +294,29 @@ def change_glyph_width_or_scale(
             hmtx[glyph_name] = (target_width, lsb)
             continue
 
+        # Check if this is a punctuation glyph that should not be scaled
+        is_punctuation = glyph_name in FULLWIDTH_PUNCTUATION_NAMES
+
+        if skip_punctuation and is_punctuation:
+            # For punctuation: only center, do not scale
+            # Calculate centering delta
+            current_width = width
+            delta = (target_width - current_width) / 2
+
+            if delta != 0:
+                glyph.coordinates.translate((delta, 0))
+                glyph.xMin, glyph.yMin, glyph.xMax, glyph.yMax = (
+                    glyph.coordinates.calcIntBounds()
+                )
+                new_lsb = lsb + int(round(delta))
+                hmtx[glyph_name] = (target_width, new_lsb)
+            else:
+                hmtx[glyph_name] = (target_width, lsb)
+
+            skipped_punctuation_count += 1
+            continue
+
+        # Normal scaling for CJK characters
         scale_w, scale_h = scale_factor
         glyph.coordinates.scale((scale_w, scale_h))
         glyph.xMin, glyph.yMin, glyph.xMax, glyph.yMax = (
@@ -296,3 +333,8 @@ def change_glyph_width_or_scale(
 
         new_lsb = lsb + int(round(delta))
         hmtx[glyph_name] = (target_width, new_lsb)
+        scaled_count += 1
+
+    # Print summary
+    if scaled_count > 0 or skipped_punctuation_count > 0:
+        print(f"  Scaled {scaled_count} CJK glyphs, skipped {skipped_punctuation_count} punctuation glyphs")

--- a/source/py/transform.py
+++ b/source/py/transform.py
@@ -233,8 +233,8 @@ def change_glyph_width_or_scale(
     match_width: int,
     target_width: int,
     scale_factor: tuple[float, float],
+    scale_punctuation_factor: tuple[float, float],
     special_names: list[str] = [],
-    punctuation_scale_factor: tuple[float, float] | None = None,
 ):
     """
     Adjusts the width or scales the glyphs in a font based on the specified parameters.
@@ -249,20 +249,16 @@ def change_glyph_width_or_scale(
         target_width (int): The new width to set for matching glyphs.
         scale_factor (tuple[float, float]): A tuple containing the scaling factors for
             width and height (scale_w, scale_h).
+        scale_punctuation_factor (tuple[float, float]): A tuple containing the scaling factors for
+            fullwidth punctuation glyphs (scale_w, scale_h).
         special_names (list[str], optional): A list of glyph names that require special
             handling instead of trim whitespace only. Defaults to an empty list.
-        punctuation_scale_factor (tuple[float, float] | None, optional): Separate scale
-            factor for fullwidth punctuation glyphs. When None, punctuation uses the
-            same scale_factor as other glyphs. Defaults to None.
 
     Notes:
         - Glyphs with a width that does not match `match_width` are skipped.
         - Glyphs with zero contours are only updated in the horizontal metrics.
         - The scaling and translation are applied to the glyph coordinates, and the
           bounding box values are recalculated.
-        - When punctuation_scale_factor is set, fullwidth punctuation glyphs (quotes,
-          ellipsis, em dash, CJK punctuation, etc.) use this factor instead of
-          scale_factor.
     """
     font["hhea"].advanceWidthMax = target_width  # type: ignore
     glyf: Any = font["glyf"]
@@ -299,13 +295,12 @@ def change_glyph_width_or_scale(
         is_punctuation = glyph_name in FULLWIDTH_PUNCTUATION_NAMES
 
         # Determine which scale factor to use
-        if is_punctuation and punctuation_scale_factor is not None:
-            use_scale_w, use_scale_h = punctuation_scale_factor
+        if is_punctuation:
+            use_scale_w, use_scale_h = scale_punctuation_factor
             punctuation_count += 1
         else:
             use_scale_w, use_scale_h = scale_factor
-            if not is_punctuation:
-                cjk_count += 1
+            cjk_count += 1
 
         # Apply scaling
         glyph.coordinates.scale((use_scale_w, use_scale_h))
@@ -326,7 +321,4 @@ def change_glyph_width_or_scale(
 
     # Print summary
     if cjk_count > 0 or punctuation_count > 0:
-        if punctuation_scale_factor is not None:
-            print(f"  Scaled {cjk_count} CJK glyphs, {punctuation_count} punctuation glyphs (with separate factor)")
-        else:
-            print(f"  Scaled {cjk_count + punctuation_count} glyphs")
+        print(f"  Scaled {cjk_count} CJK glyphs, {punctuation_count} punctuation glyphs")

--- a/source/py/transform.py
+++ b/source/py/transform.py
@@ -234,7 +234,7 @@ def change_glyph_width_or_scale(
     target_width: int,
     scale_factor: tuple[float, float],
     special_names: list[str] = [],
-    skip_punctuation: bool = False,
+    punctuation_scale_factor: tuple[float, float] | None = None,
 ):
     """
     Adjusts the width or scales the glyphs in a font based on the specified parameters.
@@ -251,17 +251,18 @@ def change_glyph_width_or_scale(
             width and height (scale_w, scale_h).
         special_names (list[str], optional): A list of glyph names that require special
             handling instead of trim whitespace only. Defaults to an empty list.
-        skip_punctuation (bool, optional): Whether to skip scaling for fullwidth
-            punctuation glyphs. These glyphs will only be centered, not scaled.
-            Defaults to True.
+        punctuation_scale_factor (tuple[float, float] | None, optional): Separate scale
+            factor for fullwidth punctuation glyphs. When None, punctuation uses the
+            same scale_factor as other glyphs. Defaults to None.
 
     Notes:
         - Glyphs with a width that does not match `match_width` are skipped.
         - Glyphs with zero contours are only updated in the horizontal metrics.
         - The scaling and translation are applied to the glyph coordinates, and the
           bounding box values are recalculated.
-        - When skip_punctuation is True, fullwidth punctuation glyphs (quotes, ellipsis,
-          em dash, CJK punctuation, etc.) are not scaled, only centered.
+        - When punctuation_scale_factor is set, fullwidth punctuation glyphs (quotes,
+          ellipsis, em dash, CJK punctuation, etc.) use this factor instead of
+          scale_factor.
     """
     font["hhea"].advanceWidthMax = target_width  # type: ignore
     glyf: Any = font["glyf"]
@@ -269,8 +270,8 @@ def change_glyph_width_or_scale(
     factor = target_width / match_width
 
     # Track statistics
-    scaled_count = 0
-    skipped_punctuation_count = 0
+    cjk_count = 0
+    punctuation_count = 0
 
     for glyph_name in font.getGlyphOrder():
         # Handle special names (legacy behavior)
@@ -294,36 +295,25 @@ def change_glyph_width_or_scale(
             hmtx[glyph_name] = (target_width, lsb)
             continue
 
-        # Check if this is a punctuation glyph that should not be scaled
+        # Check if this is a punctuation glyph
         is_punctuation = glyph_name in FULLWIDTH_PUNCTUATION_NAMES
 
-        if skip_punctuation and is_punctuation:
-            # For punctuation: only center, do not scale
-            # Calculate centering delta
-            current_width = width
-            delta = (target_width - current_width) / 2
+        # Determine which scale factor to use
+        if is_punctuation and punctuation_scale_factor is not None:
+            use_scale_w, use_scale_h = punctuation_scale_factor
+            punctuation_count += 1
+        else:
+            use_scale_w, use_scale_h = scale_factor
+            if not is_punctuation:
+                cjk_count += 1
 
-            if delta != 0:
-                glyph.coordinates.translate((delta, 0))
-                glyph.xMin, glyph.yMin, glyph.xMax, glyph.yMax = (
-                    glyph.coordinates.calcIntBounds()
-                )
-                new_lsb = lsb + int(round(delta))
-                hmtx[glyph_name] = (target_width, new_lsb)
-            else:
-                hmtx[glyph_name] = (target_width, lsb)
-
-            skipped_punctuation_count += 1
-            continue
-
-        # Normal scaling for CJK characters
-        scale_w, scale_h = scale_factor
-        glyph.coordinates.scale((scale_w, scale_h))
+        # Apply scaling
+        glyph.coordinates.scale((use_scale_w, use_scale_h))
         glyph.xMin, glyph.yMin, glyph.xMax, glyph.yMax = (
             glyph.coordinates.calcIntBounds()
         )
 
-        scaled_width = int(round(width * scale_w))
+        scaled_width = int(round(width * use_scale_w))
         delta = (target_width - scaled_width) / 2
 
         glyph.coordinates.translate((delta, 0))
@@ -333,8 +323,10 @@ def change_glyph_width_or_scale(
 
         new_lsb = lsb + int(round(delta))
         hmtx[glyph_name] = (target_width, new_lsb)
-        scaled_count += 1
 
     # Print summary
-    if scaled_count > 0 or skipped_punctuation_count > 0:
-        print(f"  Scaled {scaled_count} CJK glyphs, skipped {skipped_punctuation_count} punctuation glyphs")
+    if cjk_count > 0 or punctuation_count > 0:
+        if punctuation_scale_factor is not None:
+            print(f"  Scaled {cjk_count} CJK glyphs, {punctuation_count} punctuation glyphs (with separate factor)")
+        else:
+            print(f"  Scaled {cjk_count + punctuation_count} glyphs")

--- a/source/py/utils.py
+++ b/source/py/utils.py
@@ -35,6 +35,11 @@ FULLWIDTH_PUNCTUATION_NAMES: Set[str] = {
     "quotedblleft.full", "quotedblright.full",
     "quoteleft.full", "quoteright.full",
 
+    # Base glyphs that may be replaced by .full variants when cv96/cv97/cv98 are frozen
+    "ellipsis", "emdash",
+    "quotedblleft", "quotedblright",
+    "quoteleft", "quoteright",
+
     # .tw variants (cv99)
     "uni3001.tw", "uni3002.tw", "uniFF01.tw", "uniFF0C.tw",
     "uniFF1A.tw", "uniFF1B.tw", "uniFF1F.tw",

--- a/source/py/utils.py
+++ b/source/py/utils.py
@@ -3,11 +3,42 @@ from os import environ, path, remove, walk
 import sys
 import shutil
 import subprocess
+from typing import Set
 from urllib.request import Request, urlopen
 from zipfile import ZIP_DEFLATED, ZipFile
 from fontTools.ttLib import TTFont, newTable
 from fontTools.merge import Merger
 from source.py.task._utils import is_ci, default_weight_map
+
+
+FULLWIDTH_PUNCTUATION_NAMES: Set[str] = {
+    # CJK Symbols and Punctuation (U+3000-U+303F)
+    "uni3000", "uni3001", "uni3002", "uni3003",
+    "uni3005", "uni3006", "uni3007",
+    "uni3008", "uni3009", "uni300A", "uni300B",
+    "uni300C", "uni300D", "uni300E", "uni300F",
+    "uni3010", "uni3011",
+    "uni3014", "uni3015", "uni3016", "uni3017",
+    "uni3018", "uni3019", "uni301A", "uni301B", "uni301C",
+    "uni3021", "uni3022", "uni3023", "uni3024", "uni3025",
+    "uni3026", "uni3027", "uni3028", "uni3029",
+    "uni3031", "uni3032", "uni3033", "uni3034", "uni3035",
+    "uni3036", "uni3037", "uni3038", "uni3039", "uni303A", "uni303B",
+
+    # Fullwidth ASCII Punctuation
+    "uniFF01", "uniFF08", "uniFF09", "uniFF0C", "uniFF0E",
+    "uniFF1A", "uniFF1B", "uniFF1F",
+    "uniFF3B", "uniFF3D", "uniFF5B", "uniFF5C", "uniFF5D", "uniFF5E",
+
+    # .full variants (cv96, cv97, cv98)
+    "ellipsis.full", "emdash.full",
+    "quotedblleft.full", "quotedblright.full",
+    "quoteleft.full", "quoteright.full",
+
+    # .tw variants (cv99)
+    "uni3001.tw", "uni3002.tw", "uniFF01.tw", "uniFF0C.tw",
+    "uniFF1A.tw", "uniFF1B.tw", "uniFF1F.tw",
+}
 
 
 def run(command: str | list[str], extra_args: list[str] | None = None, log=not is_ci()):

--- a/source/schema.json
+++ b/source/schema.json
@@ -486,6 +486,11 @@
           ],
           "description": "Scale factor for CN / JP glyphs with <factor> or [<width_factor>,<height_factor>](e.g. 1.1 or [1.2, 1.1])",
           "default": 1.0
+        },
+        "scale_skip_punctuation": {
+          "type": "boolean",
+          "description": "Whether to skip scaling for fullwidth punctuation glyphs when using scale_factor",
+          "default": false
         }
       },
       "required": [

--- a/source/schema.json
+++ b/source/schema.json
@@ -487,10 +487,14 @@
           "description": "Scale factor for CN / JP glyphs with <factor> or [<width_factor>,<height_factor>](e.g. 1.1 or [1.2, 1.1])",
           "default": 1.0
         },
-        "scale_skip_punctuation": {
-          "type": "boolean",
-          "description": "Whether to skip scaling for fullwidth punctuation glyphs when using scale_factor",
-          "default": false
+        "scale_punctuation_factor": {
+          "type": [
+            "number",
+            "array",
+            "null"
+          ],
+          "description": "Scale factor for fullwidth punctuation glyphs. When null, punctuation uses the same scale_factor as other glyphs",
+          "default": null
         }
       },
       "required": [


### PR DESCRIPTION
## 概述

新增 `--cn-scale-punctuation-factor` 选项（配置文件：`cn.scale_punctuation_factor`(optional)），在使用 `--cn-scale-factor` 时可以对全角标点符号的缩放倍率进行指定。

Fixed #718 

## 动机

使用 `--cn-scale-factor` 缩放中日韩字符时，全角标点符号（引号、省略号、破折号等）也会被一起缩放，可能导致以下问题：

- 中英混排时出现明显的标点符号高度不均（如图）
- 省略号 `……` 连用时，两个符号之间的点距离过近
- 引号等靠近字框边缘的标点符号可能溢出预期位置

本 PR 添加了一项配置参数，以允许用户使用不同北路缩放 CJK 汉字持全角标点符号。

### 使用 `scale-punctuation-factor=1.0` 调整前（`scale-factor=1.15`）：

<img width="40%" alt="image" src="https://github.com/user-attachments/assets/2acf7b8d-ce69-469f-83d0-153aeb9409de" />

### 使用 `scale-punctuation-factor=1.0` 调整后（`scale-factor=1.15`）：

<img width="40%" alt="image" src="https://github.com/user-attachments/assets/fac77a52-d5b7-40ba-af7d-50aa2f978502" />

## 使用方法

**命令行：**
```bash
python build.py --cn --cn-scale-factor 1.15 --cn-scale-punctuation-factor 1.0
```

**config.json：**
```
{
  "cn": {
    "enable": true,
    "scale_factor": 1.15,
    "scale_punctuation_factor": 1.0
  }
}
```

## 涵盖的标点符号

以下标点符号会被排除在缩放之外：
- CJK 符号和标点 (U+3000-U+303F)
- 全角 ASCII 标点 (U+FF01-U+FF5E)
- cv96/cv97/cv98 对应的 .full 变体
- cv99 对应的 .tw 变体（繁体中文居中标点）

## 上述标点符号使用如下方式查找：

### 字形名称验证方式

通过 fontTools 解析 CN base font，获取实际存在的全角标点字形名称。

**步骤 1：下载 CN base font**

```bash
# 从 GitHub Releases 下载
wget https://github.com/subframe7536/maple-font/releases/download/cn-base/cn-base-static.zip
unzip cn-base-static.zip -d source/cn/static/
```

**步骤 2：解析字体并筛选标点符号**

```python
from fontTools.ttLib import TTFont

font = TTFont("source/cn/static/MapleMonoCN-Regular.ttf")
cmap = font.getBestCmap()  # Unicode -> glyph name

# 定义标点符号的 Unicode 范围
punctuation_ranges = [
    (0x3000, 0x303F, "CJK Symbols and Punctuation"),
    (0xFF01, 0xFF5E, "Fullwidth ASCII Punctuation"),
    (0x2010, 0x2027, "General Punctuation"),
]

# 遍历每个范围，获取字形名称和宽度
for start, end, category in punctuation_ranges:
    print(f"## {category}")
    for cp in range(start, end + 1):
        if cp in cmap:
            glyph_name = cmap[cp]
            width = font["hmtx"][glyph_name][0]
            print(f"  U+{cp:04X}: {glyph_name} (width={width})")
```

步骤 3：检查 .full 和 .tw 变体

```python
# 检查所有 .full 变体（cv96/cv97/cv98）
for glyph_name in font.getGlyphOrder():
    if ".full" in glyph_name:
        width = font["hmtx"][glyph_name][0]
        print(f"  {glyph_name} (width={width})")

# 检查所有 .tw 变体（cv99）
for glyph_name in font.getGlyphOrder():
    if ".tw" in glyph_name:
        width = font["hmtx"][glyph_name][0]
        print(f"  {glyph_name} (width={width})")
```

**筛选结果：**

|类别|字形数量|宽度|
|---|---|---|
| CJK Symbols and Punctuation | 46 | 1200 |
| Fullwidth ASCII Punctuation | 14 | 1200 |
| .full 变体 (cv96/cv97/cv98) | 6 | 1200 |
| .tw 变体 (cv99) | 7 | 1200 |

注：基础版本的 ellipsis、emdash、quoteleft、quoteright、quotedblleft、quotedblright 宽度为 600（半宽），当启用 cv96/cv97/cv98
时会被替换为对应的 .full 版本（全宽），因此只需包含 .full 版本即可。

_Co-worked with Claude_