### PR TITLE
Add `--cn-wenyuan` option to use Wenyuan CN base archive

### DIFF
--- a/build.py
+++ b/build.py
@@ -294,6 +294,11 @@ def parse_args(args: list[str] | None = None):
         help="Reinstantiate variable CN base font",
     )
     build_group.add_argument(
+        "--cn-wenyuan",
+        action="store_true",
+        help="Use cn-base-static-wenyuan.zip as the CN base font archive",
+    )
+    build_group.add_argument(
         "--archive",
         action="store_true",
         help="Build font archives with config and license. If it has the `--cache` flag, only archive NF and CN formats",
@@ -401,6 +406,8 @@ class FontConfig:
             "use_static_base_font": True,  # Deprecated. Always `True`
             # scale factor for CN glyphs
             "scale_factor": (1.0, 1.0),
+            # CN static base font archive to download
+            "base_zip_path": "cn-base-static.zip",
         }
         self.glyph_width = 600
         self.glyph_width_cn_narrow = 1000
@@ -529,6 +536,9 @@ class FontConfig:
             self.cn["scale_factor"] = args.cn_scale_factor
         if isinstance(self.cn["scale_factor"], (float, list)):
             self.cn["scale_factor"] = parse_scale_factor(self.cn["scale_factor"])
+
+        if args.cn_wenyuan:
+            self.cn["base_zip_path"] = "cn-base-static-wenyuan.zip"
 
     def _apply_build_options(self, args):
         """Apply general build options."""
@@ -793,9 +803,12 @@ class BuildOption:
                 '\nNo `"cn.enable": true` in config.json or `--cn` / `--cn-both` in argv. Skip CN build.'
             )
             return False
-        return self.__ensure_cn_static_fonts(clean_cache=config.cn["clean_cache"])
+        return self.__ensure_cn_static_fonts(
+            clean_cache=config.cn["clean_cache"],
+            zip_path=config.cn["base_zip_path"],
+        )
 
-    def __ensure_cn_static_fonts(self, clean_cache: bool) -> bool:
+    def __ensure_cn_static_fonts(self, clean_cache: bool, zip_path: str) -> bool:
         if clean_cache:
             print("Clean CN static fonts")
             shutil.rmtree(self.cn_static_dir, ignore_errors=True)
@@ -804,7 +817,6 @@ class BuildOption:
             return True
 
         tag = "cn-base"
-        zip_path = "cn-base-static.zip"
         if download_cn_base_font(
             tag=tag,
             zip_path=zip_path,


### PR DESCRIPTION
### Motivation
- Allow selecting an alternative CN static base archive (`cn-base-static-wenyuan.zip`) for CN builds without changing defaults.

### Description
- Add a new CLI option `--cn-wenyuan` in `parse_args` to toggle the Wenyuan archive selection.
- Add `cn.base_zip_path` to `FontConfig` with default `"cn-base-static.zip"` and override it to `"cn-base-static-wenyuan.zip"` when `--cn-wenyuan` is passed.
- Thread the configured `zip_path` into `BuildOption.should_build_cn` and `BuildOption.__ensure_cn_static_fonts` and remove the hardcoded archive name.
- All changes are contained in `build.py` and preserve existing behavior when the new flag is not used.

### Testing
- Ran `python -m py_compile build.py` which succeeded. 
- Confirmed `--cn-wenyuan` appears in `python build.py --help`. 
- Verified `python build.py --dry --cn-wenyuan` shows `"base_zip_path": "cn-base-static-wenyuan.zip"` in the config output. 
- Ran `git diff --check` which returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a545738504483309e3d97cfd2ac19fb)