### PR TITLE
Fix variable instance names and CJK metrics

### DIFF
--- a/scripts/font_ops/merge.py
+++ b/scripts/font_ops/merge.py
@@ -44,12 +44,7 @@ def merge_ttfonts(
         base_font["maxp"].numGlyphs = len(updated_glyph_order)
 
         if "cmap" in extra_font and "cmap" in base_font:
-            base_cmap = base_font["cmap"].getBestCmap()
-            extra_cmap = extra_font["cmap"].getBestCmap()
-            if base_cmap and extra_cmap:
-                for codepoint, glyph_name in extra_cmap.items():
-                    if glyph_name in glyphs_to_add and codepoint not in base_cmap:
-                        base_cmap[codepoint] = glyph_name
+            _merge_cmap(base_font, extra_font, set(glyphs_to_add))
 
         if "hhea" in base_font:
             if base_hmtx:
@@ -58,3 +53,35 @@ def merge_ttfonts(
         return base_font
     except Exception:
         raise
+
+
+def _merge_cmap(base_font: TTFont, extra_font: TTFont, glyphs_to_add: set[str]) -> None:
+    base_codepoints = set(base_font["cmap"].getBestCmap() or {})
+    extra_cmap = extra_font["cmap"].getBestCmap() or {}
+    entries = {
+        codepoint: glyph_name
+        for codepoint, glyph_name in extra_cmap.items()
+        if glyph_name in glyphs_to_add and codepoint not in base_codepoints
+    }
+    if not entries:
+        return
+
+    for table in base_font["cmap"].tables:
+        if table.isUnicode():
+            table.cmap.update(
+                {
+                    codepoint: glyph_name
+                    for codepoint, glyph_name in entries.items()
+                    if _cmap_supports_codepoint(table.format, codepoint)
+                }
+            )
+
+
+def _cmap_supports_codepoint(table_format: int, codepoint: int) -> bool:
+    if table_format == 0:
+        return codepoint <= 0xFF
+    if table_format in (2, 4, 6):
+        return codepoint <= 0xFFFF
+    if table_format in (10, 12, 13):
+        return codepoint <= 0x10FFFF
+    return codepoint <= 0xFFFF

--- a/scripts/font_ops/names.py
+++ b/scripts/font_ops/names.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Protocol
 
+from scripts.font_ops.constant import INSTANCE_WEIGHT_MAPPING
 from scripts.font_ops.fonttools import TTFont
 from scripts.utils.logging import logger
 
@@ -75,6 +76,8 @@ def update_font_names(
     narrow: bool = False,
     variable: bool = False,
 ):
+    if variable:
+        ensure_variable_instance_names(font)
     font["name"].removeNames(platformID=1)
     if len(family_name) > 31:
         logger.warning(
@@ -107,3 +110,54 @@ def update_font_names(
     if not is_skip_subfamily and preferred_family_name and preferred_style_name:
         set_font_name(font, preferred_family_name, 16)
         set_font_name(font, preferred_style_name, 17)
+
+
+def ensure_variable_instance_names(font: TTFont) -> None:
+    """Give each fvar instance a stable, non-reserved style name record."""
+    if "fvar" not in font or "name" not in font:
+        return
+
+    name_table = font["name"]
+    weight_names = {
+        value: name.title().replace("Semibold", "SemiBold")
+        for name, value in INSTANCE_WEIGHT_MAPPING.items()
+    }
+    used_name_ids = {record.nameID for record in name_table.names}
+    next_name_id = max(used_name_ids, default=255) + 1
+    assigned: dict[str, int] = {}
+
+    for instance in font["fvar"].instances:
+        weight = int(round(float(instance.coordinates.get("wght", 400))))
+        fallback_name = weight_names.get(weight, str(weight))
+        current_name = name_table.getDebugName(instance.subfamilyNameID)
+        name = (
+            current_name
+            if current_name and current_name != "Regular"
+            else fallback_name
+        )
+
+        name_id = assigned.get(name)
+        if name_id is None:
+            name_id = _find_variable_instance_name_id(name_table, name)
+        if name_id is None or name_id in {1, 2, 3, 4, 5, 6, 16, 17, 25}:
+            while next_name_id in used_name_ids:
+                next_name_id += 1
+            name_id = next_name_id
+            used_name_ids.add(name_id)
+            next_name_id += 1
+            set_font_name(font, name, name_id)
+        assigned[name] = name_id
+        instance.subfamilyNameID = name_id
+        instance.postscriptNameID = 0xFFFF
+
+
+def _find_variable_instance_name_id(name_table, value: str) -> int | None:
+    for record in name_table.names:
+        if record.nameID in {1, 2, 3, 4, 5, 6, 16, 17, 25}:
+            continue
+        try:
+            if record.toUnicode() == value:
+                return int(record.nameID)
+        except UnicodeDecodeError:
+            continue
+    return None

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -891,6 +891,7 @@ def build_cjk_extended_variable_fonts(
                     merged_font, extra_path
                 )
                 recalculate_font_metrics(merged_font)
+                merged_font.table("OS/2").xAvgCharWidth = font_config.get_target_width()
                 drop_font_tables(merged_font, ("HVAR", "VVAR"))
 
                 locale_suffix = output_locale or entry.locale_name


### PR DESCRIPTION
### Motivation

- Fix variable-font instance name collisions that caused different instances to show the same style name in FontView.  
- Fix CJK static merge producing missing glyph mappings (glyphs shown as squares) by ensuring cmap entries are properly merged.  
- Align CJK variable `OS/2.xAvgCharWidth` with the Latin monospace width to avoid excessive CJK spacing in Windows/font viewers.

### Description

- Add `ensure_variable_instance_names` to `scripts/font_ops/names.py` and invoke it from `update_font_names` when `variable=True`, so each `fvar` instance receives a stable, non-reserved nameID and `postscriptNameID` is set to `0xFFFF`.  
- Replace ad-hoc `getBestCmap()` edits in `scripts/font_ops/merge.py` with a `_merge_cmap` helper that writes new codepoint→glyph mappings into every Unicode `cmap` subtable that can encode the codepoint, and add `_cmap_supports_codepoint` to respect subtable formats.  
- After merging CJK variable fonts, force `merged_font.table("OS/2").xAvgCharWidth = font_config.get_target_width()` in `scripts/pipeline.py` so merged CJK variable outputs keep the Latin monospace average width.  
- Files changed: `scripts/font_ops/names.py`, `scripts/font_ops/merge.py`, `scripts/pipeline.py`.

### Testing

- Ran `uv run ruff check scripts/font_ops/names.py scripts/font_ops/merge.py scripts/pipeline.py` and it passed.  
- Ran `uv run pyrefly check scripts/font_ops/names.py scripts/font_ops/merge.py scripts/pipeline.py` and it passed.  
- Ran unit subset `uv run python -m unittest scripts.tests.test_font_generation` and it passed.  
- Ran full unit discovery `uv run python -m unittest discover -s scripts/tests` which reported unrelated pre-existing issues (3 failures, 1 error) not caused by these changes; those failures are assertions about name identifier year and a test expecting a resolver object shape.  
- Ran `uv run build.py --dry` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61d259ff2483308588dceb4cb5a35a)