### PR TITLE
update nerdfont and python versions, add missing dockerfile-debian dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.14-slim
 
 # Install system dependencies including FontForge
 RUN apt-get update \
-    && apt-get install -y build-essential fontforge git git-lfs \
+    && apt-get install -y build-essential fontforge git git-lfs ttfautohint \
     && rm -rf /var/lib/apt/lists/*
 
 # Set working directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.14-slim
 
 # Install system dependencies including FontForge
 RUN apt-get update \
-    && apt-get install -y fontforge \
+    && apt-get install -y build-essential fontforge git git-lfs \
     && rm -rf /var/lib/apt/lists/*
 
 # Set working directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 # Install system dependencies including FontForge
 RUN apt-get update \

--- a/source/schema.json
+++ b/source/schema.json
@@ -477,7 +477,7 @@
         "version": {
           "type": "string",
           "description": "Target version of Nerd-Font. If font-patcher not exists when need to use it or there is no prebuild font for current version, will download from Github",
-          "default": "3.2.1"
+          "default": "3.5.0"
         },
         "mono": {
           "type": "boolean",


### PR DESCRIPTION
🙇🏽 Thank you 🙇🏽 for such an _awesome_ font... it's my "go-to" for coding on all my dev platforms!

**This PR:**
- updates to the recent [NerdFont 3.5.0](https://github.com/ryanoasis/nerd-fonts/releases/tag/v3.5.0) release
- Updates the version of Python used in the Dockerfile to the more-recent `python:3.14-slim`
- Adds missing, but required packages to the Dockerfile
  - `python:3.14-slim` defaults to the Debian `trixie` release
  - it's missing `build-essential`, `git`, `git-lfs`, and `ttfautohint`
  - without those packages, the Python `requirements.txt` cannot be met
  - (the commit message says `arm64`, but I don't think it has anything to do with architecture)

I've tested this on macOS/OrbStack and `x86_64` Linux, generating _many_ variants via the `Dockerfile`.