### PR TITLE
Fix NFPropo CJK width handling and compact Nerd Font markers

### DIFF
--- a/docs/choose.md
+++ b/docs/choose.md
@@ -40,8 +40,8 @@ For example, `--normal --no-liga --width narrow` produces `MapleMonoNormalNLNR-R
 | `OTF`            | `MapleMono-Regular.otf`    | A static OpenType font for desktop applications with OpenType support.                              |
 | `WOFF2`          | `MapleMono-Regular.woff2`  | A compressed WOFF2 font intended mainly for web pages.                                              |
 | `NF`             | `MapleMono-NF-Regular.ttf` | Includes Nerd Font icons; `NF` can also be combined with feature and width suffixes.                |
-| `NFMono`         | `MapleMono-NFo-Regular.ttf` | Fixed-width Nerd Font icons; release packages use the `NFMono` label and output directory.           |
-| `NFPropo`        | `MapleMono-NFr-Regular.ttf` | Proportional Nerd Font icons; release packages use the `NFPropo` label and output directory.         |
+| `NFMono`         | `MapleMono-NFM-Regular.ttf` | Fixed-width Nerd Font icons; release packages use the `NFMono` label and output directory.           |
+| `NFPropo`        | `MapleMono-NFP-Regular.ttf` | Proportional Nerd Font icons; release packages use the `NFPropo` label and output directory.         |
 
 ### CJK Character Sets
 
@@ -54,7 +54,7 @@ CJK outputs use a locale suffix. The coverage below follows each built-in locale
 | `JP`   | Japanese CP932 coverage: Hiragana, Katakana and Katakana Phonetic Extensions, Japanese punctuation and symbols, enclosed CJK characters, and CP932 Kanji. See the [JP configuration](../source/cjk/jp/config-jp.json).                                                                                            | `MapleMono-JP-Regular.ttf` | `MapleMono-NF-JP-Regular.ttf` |
 | `KR`   | Korean script coverage: Hangul syllables (`U+AC00–U+D7A3`), Hangul Compatibility Jamo, halfwidth Hangul, Korean punctuation and symbols, plus selected enclosed and unit characters. The KR locale does not add the Han ideograph range. See the [KR configuration](../source/cjk/kr/config-kr.json).             | `MapleMono-KR-Regular.ttf` | `MapleMono-NF-KR-Regular.ttf` |
 
-Locales can be combined with feature and width settings. For example, `--cjk jp --nf --width slim` produces the static file `MapleMonoSL-NF-JP-Regular.ttf`; Mono and Propo custom builds use `NFMono-JP` / `Variable-NFMono-JP` and `NFPropo-JP` / `Variable-NFPropo-JP` directories while preserving the `NFo` and `NFr` internal filename markers. CJK builds are disabled by default; see the [build guide](build.md) for configuration details. Release packages include default NF locales only.
+Locales can be combined with feature and width settings. For example, `--cjk jp --nf --width slim` produces the static file `MapleMonoSL-NF-JP-Regular.ttf`; Mono and Propo custom builds use `NFMono-JP` / `Variable-NFMono-JP` and `NFPropo-JP` / `Variable-NFPropo-JP` directories while preserving the `NFM` and `NFP` internal filename markers. CJK builds are disabled by default; see the [build guide](build.md) for configuration details. Release packages include default NF locales only.
 
 ## Hinted and Unhinted Fonts
 

--- a/scripts/cjk/static.py
+++ b/scripts/cjk/static.py
@@ -214,6 +214,12 @@ def postprocess_cjk_extended_static_font(
         entry.common_options.narrow,
     )
     skip_verify = apply_cjk_width_transform(font, font_config, entry.common_options)
+    if font_config.get_nf_variant().suffix == "Propo":
+        font.table("post").isFixedPitch = False
+        os2 = font.table("OS/2")
+        os2.panose.bProportion = 0
+        os2.panose.bSpacing = 0
+        skip_verify = True
     if entry.is_builtin and entry.common_options.fix_meta_table and entry.preset_spec:
         apply_cjk_meta_table(
             font,

--- a/scripts/cjk/static.py
+++ b/scripts/cjk/static.py
@@ -118,15 +118,11 @@ def apply_cjk_width_transform(
         "quotedblright.full",
     ]
 
-    skip_verify = False
+    skip_verify = font_config.get_nf_variant().suffix == "Propo"
     if target_width or scale_factor:
         match_width = 2 * font_config.glyph_width
         is_slim = font_config.get_width_name() != "SL"
         if target_width and is_slim:
-            font.table("post").isFixedPitch = False
-            os2 = font.table("OS/2")
-            os2.panose.bProportion = 0
-            os2.panose.bSpacing = 0
             font.table("hhea").advanceWidthMax = target_width
             logger.warning(
                 "Changed CJK glyph width; mark font as proportional and skip width checks"
@@ -150,7 +146,7 @@ def apply_cjk_width_transform(
             scale_factor=scale_factor,
             special_names=special_scale_names,
         )
-        skip_verify = bool(target_width and is_slim)
+        skip_verify = skip_verify or bool(target_width and is_slim)
     elif font_config.get_width_name():
         change_glyph_width_or_scale(
             font=font,
@@ -169,6 +165,12 @@ def apply_cjk_width_transform(
             scale_zero_width=False,
         )
         font.table("hhea").advanceWidthMax = previous_advance_width_max
+
+    if skip_verify:
+        font.table("post").isFixedPitch = False
+        os2 = font.table("OS/2")
+        os2.panose.bProportion = 0
+        os2.panose.bSpacing = 0
 
     return skip_verify
 
@@ -214,12 +216,6 @@ def postprocess_cjk_extended_static_font(
         entry.common_options.narrow,
     )
     skip_verify = apply_cjk_width_transform(font, font_config, entry.common_options)
-    if font_config.get_nf_variant().suffix == "Propo":
-        font.table("post").isFixedPitch = False
-        os2 = font.table("OS/2")
-        os2.panose.bProportion = 0
-        os2.panose.bSpacing = 0
-        skip_verify = True
     if entry.is_builtin and entry.common_options.fix_meta_table and entry.preset_spec:
         apply_cjk_meta_table(
             font,

--- a/scripts/font_ops/nerd_font.py
+++ b/scripts/font_ops/nerd_font.py
@@ -39,8 +39,7 @@ class NerdFontVariant:
 
     @property
     def compact(self) -> str:
-        # Keep the historical NFo/NFr output suffixes used by the build paths.
-        return self.suffix[1] if self.suffix else ""
+        return self.suffix[0] if self.suffix else ""
 
     @property
     def symbol(self) -> str:

--- a/scripts/tests/test_build_util.py
+++ b/scripts/tests/test_build_util.py
@@ -164,38 +164,21 @@ class PostprocessCJKStaticFontTest(unittest.TestCase):
 
         apply_meta_mock.assert_not_called()
 
-    def test_nf_propo_marks_font_proportional_and_skips_width_validation(self) -> None:
+    def test_nf_propo_width_transform_marks_font_proportional(self) -> None:
         font_config = BuildConfigResolver().load_defaults()
         font_config.nerd_font.propo = True
         font = MagicMock()
 
-        with (
-            patch("scripts.cjk.static.remove_target_glyph"),
-            patch(
-                "scripts.cjk.static.apply_cjk_names",
-                return_value="MapleMono-NFP-CN-Regular",
-            ),
-            patch(
-                "scripts.cjk.static.apply_cjk_width_transform",
-                return_value=False,
-            ),
-            patch("scripts.cjk.static.apply_cjk_meta_table"),
-            patch("scripts.cjk.static.apply_cjk_metrics"),
-            patch("scripts.cjk.static.apply_binary_features"),
-            patch("scripts.cjk.static.verify_cjk_widths") as verify_widths,
-        ):
-            postprocess_cjk_extended_static_font(
-                font,
-                make_builtin_entry(),
-                font_config,
-                make_runtime_context(),
-                "Regular",
-            )
+        skip_verify = apply_cjk_width_transform(
+            font,
+            font_config,
+            CJKCommonBuildOptions(),
+        )
 
         self.assertFalse(font.table("post").isFixedPitch)
         self.assertEqual(font.table("OS/2").panose.bProportion, 0)
         self.assertEqual(font.table("OS/2").panose.bSpacing, 0)
-        self.assertTrue(verify_widths.call_args.args[3])
+        self.assertTrue(skip_verify)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_build_util.py
+++ b/scripts/tests/test_build_util.py
@@ -164,6 +164,39 @@ class PostprocessCJKStaticFontTest(unittest.TestCase):
 
         apply_meta_mock.assert_not_called()
 
+    def test_nf_propo_marks_font_proportional_and_skips_width_validation(self) -> None:
+        font_config = BuildConfigResolver().load_defaults()
+        font_config.nerd_font.propo = True
+        font = MagicMock()
+
+        with (
+            patch("scripts.cjk.static.remove_target_glyph"),
+            patch(
+                "scripts.cjk.static.apply_cjk_names",
+                return_value="MapleMono-NFP-CN-Regular",
+            ),
+            patch(
+                "scripts.cjk.static.apply_cjk_width_transform",
+                return_value=False,
+            ),
+            patch("scripts.cjk.static.apply_cjk_meta_table"),
+            patch("scripts.cjk.static.apply_cjk_metrics"),
+            patch("scripts.cjk.static.apply_binary_features"),
+            patch("scripts.cjk.static.verify_cjk_widths") as verify_widths,
+        ):
+            postprocess_cjk_extended_static_font(
+                font,
+                make_builtin_entry(),
+                font_config,
+                make_runtime_context(),
+                "Regular",
+            )
+
+        self.assertFalse(font.table("post").isFixedPitch)
+        self.assertEqual(font.table("OS/2").panose.bProportion, 0)
+        self.assertEqual(font.table("OS/2").panose.bSpacing, 0)
+        self.assertTrue(verify_widths.call_args.args[3])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_nerd_font.py
+++ b/scripts/tests/test_nerd_font.py
@@ -19,7 +19,7 @@ class NerdFontHelpersTest(unittest.TestCase):
     def test_variant_preserves_nf_output_names(self) -> None:
         self.assertEqual(NerdFontVariant.from_options().symbol, "NF")
         self.assertEqual(NerdFontVariant.from_options(mono=True).suffix, "Mono")
-        self.assertEqual(NerdFontVariant.from_options(mono=True).symbol, "NFo")
+        self.assertEqual(NerdFontVariant.from_options(mono=True).symbol, "NFM")
         self.assertEqual(
             NerdFontVariant.from_options(mono=True).directory_name, "NFMono"
         )
@@ -27,7 +27,7 @@ class NerdFontHelpersTest(unittest.TestCase):
             NerdFontVariant.from_options(mono=True).cjk_directory_name("CN"),
             "NFMono-CN",
         )
-        self.assertEqual(NerdFontVariant.from_options(propo=True).symbol, "NFr")
+        self.assertEqual(NerdFontVariant.from_options(propo=True).symbol, "NFP")
         self.assertEqual(
             NerdFontVariant.from_options(propo=True).directory_name, "NFPropo"
         )
@@ -50,7 +50,7 @@ class NerdFontHelpersTest(unittest.TestCase):
         )
         self.assertEqual(
             variant.patched_style_path("fonts", "MapleMono", "Italic"),
-            Path("fonts/MapleMono-NFo-Italic.ttf"),
+            Path("fonts/MapleMono-NFM-Italic.ttf"),
         )
         self.assertEqual(
             variant.patched_font_path("fonts", "MapleMono-Regular.ttf"),


### PR DESCRIPTION
### Motivation

- NFPropo CJK builds fail width verification because proportional glyphs were still treated as monospaced during postprocessing.  
- The compact Nerd Font marker generation used the wrong suffix index, producing legacy internal markers that don't match the new compact naming intent.  

### Description

- Change `NerdFontVariant.compact` to derive the compact marker from `self.suffix[0]` so Mono/Propo produce `NFM`/`NFP` internal markers instead of the previous values.  
- In `postprocess_cjk_extended_static_font`, detect `NFPropo` and mark the font as proportional by setting `post.isFixedPitch = False`, clearing `OS/2` PANOSE proportion/spacing, and skipping width verification for NFPropo CJK outputs.  
- Update `docs/choose.md` to reflect the new `NFM` and `NFP` internal filename markers for NFMono/NFPropo outputs.  
- Add a unit test (`test_nf_propo_marks_font_proportional_and_skips_width_validation`) and adjust existing Nerd Font tests to assert the new compact markers and patched-style filenames.  

### Testing

- Ran formatting and linters with `uv run ruff format --check .` and `uv run ruff check .` which passed.  
- Ran static type checks with `uv run pyrefly check` which passed.  
- Ran the unit suite with `uv run python -m unittest discover -s scripts/tests`, all tests passed (373 tests, OK).  
- Performed a dry build with `uv run build.py --dry` which completed without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ae7e6c46083309ae16606d23c170f)