### PR TITLE
Remove overlaps from CJK static font instances

### DIFF
--- a/scripts/cjk/builder.py
+++ b/scripts/cjk/builder.py
@@ -62,6 +62,7 @@ from scripts.font_ops.fonttools import (
     TTFont,
     instantiate_variable_font,
     load_font,
+    remove_overlaps,
     save_font_atomic,
 )
 from scripts.font_ops.names import FontNameConfig, set_font_name, update_font_names
@@ -1345,6 +1346,7 @@ def finalize_static_font_instance(
     )
     drop_font_tables(instance, ("kern", "GPOS"))
     remove_mac_name_records(instance)
+    remove_overlaps(instance)
     instance.save(output_path)
     logger.info("Instantiate CJK base static font to %s", output_path)
 

--- a/scripts/font_ops/fonttools.py
+++ b/scripts/font_ops/fonttools.py
@@ -7,6 +7,7 @@ from typing import Any, Literal, Protocol, cast, overload
 
 from fontTools.ttLib import TTFont as FontToolsTTFont
 from fontTools.ttLib import newTable
+from fontTools.ttLib.removeOverlaps import removeOverlaps as _remove_overlaps
 from fontTools.varLib.instancer import (
     instantiateVariableFont as _instantiate_variable_font,
 )
@@ -201,6 +202,11 @@ def instantiate_variable_font(
     return adapt_ttfont(instance)
 
 
+def remove_overlaps(font: TTFont) -> None:
+    """Merge overlapping contours and discard invalidated hinting."""
+    _remove_overlaps(font)
+
+
 def save_font_atomic(font: TTFont, target_path: str | Path) -> Path:
     """Save a font through a sibling temporary file and atomically publish it."""
     target = Path(target_path)
@@ -232,5 +238,6 @@ __all__ = [
     "adapt_ttfont",
     "instantiate_variable_font",
     "newTable",
+    "remove_overlaps",
     "save_font_atomic",
 ]

--- a/scripts/tests/test_cjk_executor.py
+++ b/scripts/tests/test_cjk_executor.py
@@ -11,6 +11,7 @@ from scripts.cjk.builder import (
     CJKBuilder,
     autohint_static_fonts,
     create_font_executor,
+    finalize_static_font_instance,
     instantiate_cjk_static_from_variable,
     instantiate_variable_font_file,
 )
@@ -51,6 +52,35 @@ def make_config(output_dir: Path) -> CJKBuildConfig:
 
 
 class CJKExecutorOwnershipTest(unittest.TestCase):
+    def test_static_instance_removes_overlaps_before_saving(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            config = make_config(Path(tmp))
+            instance = MagicMock()
+            instance.__contains__.return_value = False
+            events: list[str] = []
+            instance.save.side_effect = lambda _path: events.append("save")
+
+            with (
+                patch("scripts.cjk.builder.update_font_names"),
+                patch("scripts.cjk.builder.drop_font_tables"),
+                patch("scripts.cjk.builder.remove_mac_name_records"),
+                patch(
+                    "scripts.cjk.builder.remove_overlaps",
+                    side_effect=lambda _font: events.append("remove_overlaps"),
+                ) as remove,
+            ):
+                finalize_static_font_instance(
+                    instance,
+                    "output.ttf",
+                    "Regular",
+                    False,
+                    config,
+                    BuildConfigResolver().load_defaults(),
+                )
+
+            remove.assert_called_once_with(instance)
+            self.assertEqual(events, ["remove_overlaps", "save"])
+
     def test_static_autohint_uses_the_caller_executor(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
### Motivation

- Fix rendering anomalies observed on Android (e.g. in WeChat) by ensuring overlapping contours in instantiated CJK static base fonts are merged before files are written.

### Description

- Add a typed wrapper `remove_overlaps` in `scripts/font_ops/fonttools.py` that calls FontTools' `removeOverlaps` implementation. 
- Call `remove_overlaps` from `finalize_static_font_instance` in `scripts/cjk/builder.py` immediately before saving the static font file. 
- Add a unit test `test_static_instance_removes_overlaps_before_saving` in `scripts/tests/test_cjk_executor.py` to verify overlap removal is invoked once and occurs before `save`.

### Testing

- Ran formatting and lint checks with `uv run ruff format --check` and `uv run ruff check` on the modified files; both passed. 
- Ran static type checks with `uv run pyrefly check`; check passed. 
- Ran unit tests with `uv run python -m unittest scripts.tests.test_cjk_executor` and full suite with `uv run python -m unittest discover -s scripts/tests`; both runs passed (targeted tests and full suite succeeded). 
- Ran a dry build with `uv run build.py --dry`; it completed without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7bdcd28f748330bd5640f10b77d13c)