### PR TITLE
fix(ci): bump actions/setup-python to v6

### DIFF
--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'


### PR DESCRIPTION
This fix eliminates a warning for "Custom Build" action:

<img width="1750" height="400" alt="image" src="https://github.com/user-attachments/assets/60ba9b2b-1334-4595-9d61-d29167faadba" />

Tested with a manually triggered workflow run, broke nothing.