### PR TITLE
fix: respect custom regular weight in designspace

### DIFF
--- a/scripts/font_ops/glyphs.py
+++ b/scripts/font_ops/glyphs.py
@@ -212,15 +212,15 @@ def prepare_designspace_source(
             raise ValueError(
                 f"Designspace source requires a continuous named wght axis: {path}"
             )
-        weight_axis.default = 400
-        axis_name = weight_axis.name
         sources = list(designspace.sources)
-        default_source = next(
-            (source for source in sources if source.location.get(axis_name) == 400),
-            None,
-        )
+        default_source = designspace.findDefault()
         if default_source is None or default_source.font is None:
-            raise ValueError(f"Designspace source is missing a wght 400 master: {path}")
+            default_design_weight = weight_axis.map_forward(weight_axis.default)
+            raise ValueError(
+                "Designspace source is missing its default wght master "
+                f"(user={weight_axis.default:g}, design={default_design_weight:g}): "
+                f"{path}"
+            )
 
         vertical_metric = _resolve_default_source_vertical_metric(default_source)
         target_vertical_metric = (
@@ -300,10 +300,28 @@ def _apply_designspace_weight_mapping(
         )
     )
     if mapping:
-        weight_axis.map = sorted(dict(mapping).items())
-        weight_axis.minimum = weight_axis.map[0][0]
-        weight_axis.maximum = weight_axis.map[-1][0]
-        weight_axis.default = 400
+        mapped_weights: dict[float, float] = {}
+        for user_weight, design_weight in mapping:
+            previous = mapped_weights.get(user_weight)
+            if previous is not None and previous != design_weight:
+                raise ValueError(
+                    "weight_mapping values must be unique and strictly increase "
+                    "from Thin to ExtraBold"
+                )
+            mapped_weights[user_weight] = design_weight
+
+        axis_map = sorted(mapped_weights.items())
+        design_weights = [design_weight for _, design_weight in axis_map]
+        if design_weights != sorted(design_weights):
+            raise ValueError(
+                "weight_mapping values must be unique and strictly increase "
+                "from Thin to ExtraBold"
+            )
+
+        weight_axis.map = axis_map
+        weight_axis.minimum = axis_map[0][0]
+        weight_axis.maximum = axis_map[-1][0]
+        weight_axis.default = weight_mapping["regular"]
 
 
 def materialize_prepared_source(

--- a/scripts/tests/test_weight_mapping.py
+++ b/scripts/tests/test_weight_mapping.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import unittest
+
+from fontTools.designspaceLib import (
+    AxisDescriptor,
+    DesignSpaceDocument,
+    InstanceDescriptor,
+    SourceDescriptor,
+)
+
+from scripts.font_ops.glyphs import _apply_designspace_weight_mapping
+
+
+STYLE_DESIGN_WEIGHTS = (
+    ("Thin", 100),
+    ("ExtraLight", 210),
+    ("Light", 320),
+    ("Regular", 400),
+    ("Medium", 490),
+    ("SemiBold", 570),
+    ("Bold", 680),
+    ("ExtraBold", 800),
+)
+
+
+def make_designspace() -> DesignSpaceDocument:
+    designspace = DesignSpaceDocument()
+    axis = AxisDescriptor()
+    axis.tag = "wght"
+    axis.name = "Weight"
+    axis.minimum = 100
+    axis.maximum = 800
+    axis.default = 400
+    axis.map = list(
+        zip(
+            (100, 200, 300, 400, 500, 600, 700, 800),
+            (100, 210, 320, 400, 490, 570, 680, 800),
+            strict=True,
+        )
+    )
+    designspace.addAxis(axis)
+
+    for style_name, design_weight in (
+        ("Thin", 100),
+        ("Regular", 400),
+        ("ExtraBold", 800),
+    ):
+        source = SourceDescriptor()
+        source.name = f"Fixture {style_name}"
+        source.styleName = style_name
+        source.location = {"Weight": design_weight}
+        source.font = object()
+        designspace.addSource(source)
+
+    for style_name, design_weight in STYLE_DESIGN_WEIGHTS:
+        instance = InstanceDescriptor()
+        instance.name = f"Fixture {style_name}"
+        instance.styleName = style_name
+        instance.designLocation = {"Weight": design_weight}
+        designspace.addInstance(instance)
+
+    return designspace
+
+
+class WeightMappingTest(unittest.TestCase):
+    def test_custom_regular_weight_remains_default_master(self) -> None:
+        designspace = make_designspace()
+        mapping = {
+            "thin": 100,
+            "extralight": 200,
+            "light": 250,
+            "regular": 300,
+            "medium": 400,
+            "semibold": 500,
+            "bold": 600,
+            "extrabold": 800,
+        }
+
+        _apply_designspace_weight_mapping(designspace, mapping)
+
+        axis = designspace.axes[0]
+        self.assertEqual(axis.default, 300)
+        self.assertEqual(axis.map_forward(axis.default), 400)
+        default_source = designspace.findDefault()
+        self.assertIsNotNone(default_source)
+        assert default_source is not None
+        self.assertEqual(default_source.styleName, "Regular")
+
+    def test_non_monotonic_weight_mapping_is_rejected(self) -> None:
+        designspace = make_designspace()
+        mapping = {
+            "thin": 100,
+            "extralight": 200,
+            "light": 250,
+            "regular": 300,
+            "medium": 400,
+            "semibold": 350,
+            "bold": 500,
+            "extrabold": 800,
+        }
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "unique and strictly increase from Thin to ExtraBold",
+        ):
+            _apply_designspace_weight_mapping(designspace, mapping)
+
+    def test_duplicate_weight_mapping_is_rejected(self) -> None:
+        designspace = make_designspace()
+        mapping = {
+            "thin": 100,
+            "extralight": 200,
+            "light": 250,
+            "regular": 300,
+            "medium": 400,
+            "semibold": 400,
+            "bold": 500,
+            "extrabold": 800,
+        }
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "unique and strictly increase from Thin to ExtraBold",
+        ):
+            _apply_designspace_weight_mapping(designspace, mapping)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix custom `weight_mapping` builds when `regular` is not 400.

The build pipeline previously rewrote the weight-axis map and then forced the axis default back to user weight `400`, while also looking for a source master at design weight `400`. With a custom mapping such as `regular = 300`, user weight `400` can map to a non-master design location (for example Medium at 490), so `DesignSpaceDocument.findDefault()` cannot resolve the default UFO source and feature preparation fails.

This PR:

- sets the `wght` axis default to the configured Regular user weight;
- uses `DesignSpaceDocument.findDefault()` to resolve the default source through the axis map instead of hard-coding design weight 400;
- validates that custom user weights remain unique/monotonic before fontmake, producing a clear error for configurations such as Medium/SemiBold being reversed;
- adds regression tests for a custom `regular = 300` mapping and invalid mappings.

Reported in https://github.com/subframe7536/maple-font/discussions/834

## Notes

The reported configuration also has `semibold = 350` and `medium = 400`, which reverses the design-space order. After the default-master bug is fixed, that mapping would otherwise fail later in varLib. This PR rejects it early with a targeted error; valid custom mappings must preserve:

`thin < extralight < light < regular < medium < semibold < bold < extrabold`
