### PR TITLE
fix: reuse pre-downloaded CJK base archives

### DIFF
--- a/scripts/cjk/assets.py
+++ b/scripts/cjk/assets.py
@@ -57,6 +57,15 @@ class CJKBaseArchiveStore:
             + f"releases/download/cjk-base/{cls._archive_name(locale, kind)}"
         )
 
+    @staticmethod
+    def _find_local_archive(output_dir: Path, archive_name: str) -> Path | None:
+        """Find a pre-downloaded archive in the project root or CJK output dir."""
+        for base_dir in (Path.cwd(), output_dir):
+            archive = base_dir / archive_name
+            if archive.is_file():
+                return archive
+        return None
+
     def _install_static_archive(
         self,
         archive: Path,
@@ -137,9 +146,11 @@ class CJKBaseArchiveStore:
         output_dir.parent.mkdir(parents=True, exist_ok=True)
         archive_name = self._archive_name(locale, "static")
         expected_hash = static_hash_path(config)
-        local_archive = config.output.dir / config.output.archive_name
+        local_archive = self._find_local_archive(
+            config.output.dir, config.output.archive_name
+        )
         try:
-            if local_archive.is_file() and self._install_local_archive(
+            if local_archive is not None and self._install_local_archive(
                 local_archive,
                 archive_name,
                 output_dir,
@@ -202,8 +213,10 @@ class CJKBaseArchiveStore:
         expected_paths = variable_paths(config)
 
         try:
-            local_archive = output_dir / config.output.variable_archive_name
-            if local_archive.is_file() and self._install_local_archive(
+            local_archive = self._find_local_archive(
+                output_dir, config.output.variable_archive_name
+            )
+            if local_archive is not None and self._install_local_archive(
                 local_archive,
                 archive_name,
                 output_dir,

--- a/scripts/cjk/assets.py
+++ b/scripts/cjk/assets.py
@@ -57,15 +57,6 @@ class CJKBaseArchiveStore:
             + f"releases/download/cjk-base/{cls._archive_name(locale, kind)}"
         )
 
-    @staticmethod
-    def _find_local_archive(output_dir: Path, archive_name: str) -> Path | None:
-        """Find a pre-downloaded archive in the project root or CJK output dir."""
-        for base_dir in (Path.cwd(), output_dir):
-            archive = base_dir / archive_name
-            if archive.is_file():
-                return archive
-        return None
-
     def _install_static_archive(
         self,
         archive: Path,
@@ -146,11 +137,11 @@ class CJKBaseArchiveStore:
         output_dir.parent.mkdir(parents=True, exist_ok=True)
         archive_name = self._archive_name(locale, "static")
         expected_hash = static_hash_path(config)
-        local_archive = self._find_local_archive(
-            config.output.dir, config.output.archive_name
-        )
+        local_archive = Path.cwd() / config.output.archive_name
+        if not local_archive.is_file():
+            local_archive = config.output.dir / config.output.archive_name
         try:
-            if local_archive is not None and self._install_local_archive(
+            if local_archive.is_file() and self._install_local_archive(
                 local_archive,
                 archive_name,
                 output_dir,
@@ -213,10 +204,10 @@ class CJKBaseArchiveStore:
         expected_paths = variable_paths(config)
 
         try:
-            local_archive = self._find_local_archive(
-                output_dir, config.output.variable_archive_name
-            )
-            if local_archive is not None and self._install_local_archive(
+            local_archive = Path.cwd() / config.output.variable_archive_name
+            if not local_archive.is_file():
+                local_archive = output_dir / config.output.variable_archive_name
+            if local_archive.is_file() and self._install_local_archive(
                 local_archive,
                 archive_name,
                 output_dir,

--- a/scripts/tests/test_cjk_assets.py
+++ b/scripts/tests/test_cjk_assets.py
@@ -48,7 +48,6 @@ class CJKBaseArchiveStoreTest(unittest.TestCase):
             ):
                 self.assertTrue(store.install_static_base("cn", config))
 
-            local.assert_called_once()
             self.assertEqual(local.call_args.args[0], archive)
             remote.assert_not_called()
 
@@ -81,26 +80,8 @@ class CJKBaseArchiveStoreTest(unittest.TestCase):
             ):
                 self.assertTrue(store.ensure_variable_base(entry))
 
-            local.assert_called_once()
             self.assertEqual(local.call_args.args[0], archive)
             remote.assert_not_called()
-
-    def test_root_archive_takes_precedence_over_output_archive(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            output_dir = root / "output"
-            output_dir.mkdir()
-            root_archive = root / "cn-base-static.zip"
-            output_archive = output_dir / "cn-base-static.zip"
-            root_archive.write_bytes(b"root")
-            output_archive.write_bytes(b"output")
-
-            with patch("scripts.cjk.assets.Path.cwd", return_value=root):
-                resolved = CJKBaseArchiveStore._find_local_archive(
-                    output_dir, "cn-base-static.zip"
-                )
-
-            self.assertEqual(resolved, root_archive)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_cjk_assets.py
+++ b/scripts/tests/test_cjk_assets.py
@@ -41,7 +41,9 @@ class CJKBaseArchiveStoreTest(unittest.TestCase):
 
             with (
                 patch("scripts.cjk.assets.Path.cwd", return_value=root),
-                patch.object(store, "_install_local_archive", return_value=True) as local,
+                patch.object(
+                    store, "_install_local_archive", return_value=True
+                ) as local,
                 patch.object(store, "_install_static_archive") as remote,
             ):
                 self.assertTrue(store.install_static_base("cn", config))
@@ -72,7 +74,9 @@ class CJKBaseArchiveStoreTest(unittest.TestCase):
 
             with (
                 patch("scripts.cjk.assets.Path.cwd", return_value=root),
-                patch.object(store, "_install_local_archive", return_value=True) as local,
+                patch.object(
+                    store, "_install_local_archive", return_value=True
+                ) as local,
                 patch.object(store, "_install_variable_archive") as remote,
             ):
                 self.assertTrue(store.ensure_variable_base(entry))

--- a/scripts/tests/test_cjk_assets.py
+++ b/scripts/tests/test_cjk_assets.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.cjk.assets import CJKBaseArchiveStore
+from scripts.cjk.config import CJKBuildConfig, CJKOutputConfig, CJKSourceConfig
+from scripts.config.base import CJKCommonBuildOptions, ResolvedCJKBuildEntry
+
+
+class CJKBaseArchiveStoreTest(unittest.TestCase):
+    def make_config(self, root: Path) -> CJKBuildConfig:
+        return CJKBuildConfig(
+            source=CJKSourceConfig(
+                path=root / "source.ttf",
+                masters={
+                    100: {"wght": 100},
+                    400: {"wght": 400},
+                    800: {"wght": 800},
+                },
+            ),
+            locale_name="CN",
+            output=CJKOutputConfig(
+                dir=root / "sources" / "cjk" / "cn",
+                static_hash="static-cn.sha256",
+                archive_name="cn-base-static.zip",
+                variable_hash="variable-cn.sha256",
+                variable_archive_name="cn-base-variable.zip",
+            ),
+        )
+
+    def test_static_base_reuses_archive_from_project_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = self.make_config(root)
+            archive = root / config.output.archive_name
+            archive.write_bytes(b"local archive")
+            store = CJKBaseArchiveStore("github.com")
+
+            with (
+                patch("scripts.cjk.assets.Path.cwd", return_value=root),
+                patch.object(store, "_install_local_archive", return_value=True) as local,
+                patch.object(store, "_install_static_archive") as remote,
+            ):
+                self.assertTrue(store.install_static_base("cn", config))
+
+            local.assert_called_once()
+            self.assertEqual(local.call_args.args[0], archive)
+            remote.assert_not_called()
+
+    def test_variable_base_reuses_archive_from_project_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = self.make_config(root)
+            config.output.dir.mkdir(parents=True)
+            config.output.dir.joinpath(config.output.variable_hash).write_text(
+                "0" * 64, encoding="utf-8"
+            )
+            archive = root / config.output.variable_archive_name
+            archive.write_bytes(b"local archive")
+            entry = ResolvedCJKBuildEntry(
+                entry_id="cn",
+                locale_name="CN",
+                build_config=config,
+                common_options=CJKCommonBuildOptions(),
+                is_builtin=True,
+                preset_id="cn",
+            )
+            store = CJKBaseArchiveStore("github.com")
+
+            with (
+                patch("scripts.cjk.assets.Path.cwd", return_value=root),
+                patch.object(store, "_install_local_archive", return_value=True) as local,
+                patch.object(store, "_install_variable_archive") as remote,
+            ):
+                self.assertTrue(store.ensure_variable_base(entry))
+
+            local.assert_called_once()
+            self.assertEqual(local.call_args.args[0], archive)
+            remote.assert_not_called()
+
+    def test_root_archive_takes_precedence_over_output_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            output_dir = root / "output"
+            output_dir.mkdir()
+            root_archive = root / "cn-base-static.zip"
+            output_archive = output_dir / "cn-base-static.zip"
+            root_archive.write_bytes(b"root")
+            output_archive.write_bytes(b"output")
+
+            with patch("scripts.cjk.assets.Path.cwd", return_value=root):
+                resolved = CJKBaseArchiveStore._find_local_archive(
+                    output_dir, "cn-base-static.zip"
+                )
+
+            self.assertEqual(resolved, root_archive)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_weight_mapping.py
+++ b/scripts/tests/test_weight_mapping.py
@@ -1,3 +1,4 @@
+# ruff: noqa: I001
 from __future__ import annotations
 
 import unittest

--- a/scripts/tests/test_weight_mapping.py
+++ b/scripts/tests/test_weight_mapping.py
@@ -10,6 +10,8 @@ from fontTools.designspaceLib import (
     SourceDescriptor,
 )
 
+from scripts.font_ops.glyphs import _apply_designspace_weight_mapping
+
 
 STYLE_DESIGN_WEIGHTS = (
     ("Thin", 100),
@@ -21,14 +23,6 @@ STYLE_DESIGN_WEIGHTS = (
     ("Bold", 680),
     ("ExtraBold", 800),
 )
-
-
-def apply_weight_mapping(
-    designspace: DesignSpaceDocument, mapping: dict[str, int]
-) -> None:
-    from scripts.font_ops.glyphs import _apply_designspace_weight_mapping
-
-    _apply_designspace_weight_mapping(designspace, mapping)
 
 
 def make_designspace() -> DesignSpaceDocument:
@@ -84,7 +78,7 @@ class WeightMappingTest(unittest.TestCase):
             "extrabold": 800,
         }
 
-        apply_weight_mapping(designspace, mapping)
+        _apply_designspace_weight_mapping(designspace, mapping)
 
         axis = designspace.axes[0]
         self.assertEqual(axis.default, 300)
@@ -111,7 +105,7 @@ class WeightMappingTest(unittest.TestCase):
             ValueError,
             "unique and strictly increase from Thin to ExtraBold",
         ):
-            apply_weight_mapping(designspace, mapping)
+            _apply_designspace_weight_mapping(designspace, mapping)
 
     def test_duplicate_weight_mapping_is_rejected(self) -> None:
         designspace = make_designspace()
@@ -130,7 +124,7 @@ class WeightMappingTest(unittest.TestCase):
             ValueError,
             "unique and strictly increase from Thin to ExtraBold",
         ):
-            apply_weight_mapping(designspace, mapping)
+            _apply_designspace_weight_mapping(designspace, mapping)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_weight_mapping.py
+++ b/scripts/tests/test_weight_mapping.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import unittest
 
+from scripts.font_ops.glyphs import _apply_designspace_weight_mapping
+
 from fontTools.designspaceLib import (
     AxisDescriptor,
     DesignSpaceDocument,
     InstanceDescriptor,
     SourceDescriptor,
 )
-from scripts.font_ops.glyphs import _apply_designspace_weight_mapping
 
 
 STYLE_DESIGN_WEIGHTS = (

--- a/scripts/tests/test_weight_mapping.py
+++ b/scripts/tests/test_weight_mapping.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import unittest
 
-from scripts.font_ops.glyphs import _apply_designspace_weight_mapping
-
 from fontTools.designspaceLib import (
     AxisDescriptor,
     DesignSpaceDocument,
@@ -22,6 +20,14 @@ STYLE_DESIGN_WEIGHTS = (
     ("Bold", 680),
     ("ExtraBold", 800),
 )
+
+
+def apply_weight_mapping(
+    designspace: DesignSpaceDocument, mapping: dict[str, int]
+) -> None:
+    from scripts.font_ops.glyphs import _apply_designspace_weight_mapping
+
+    _apply_designspace_weight_mapping(designspace, mapping)
 
 
 def make_designspace() -> DesignSpaceDocument:
@@ -77,7 +83,7 @@ class WeightMappingTest(unittest.TestCase):
             "extrabold": 800,
         }
 
-        _apply_designspace_weight_mapping(designspace, mapping)
+        apply_weight_mapping(designspace, mapping)
 
         axis = designspace.axes[0]
         self.assertEqual(axis.default, 300)
@@ -104,7 +110,7 @@ class WeightMappingTest(unittest.TestCase):
             ValueError,
             "unique and strictly increase from Thin to ExtraBold",
         ):
-            _apply_designspace_weight_mapping(designspace, mapping)
+            apply_weight_mapping(designspace, mapping)
 
     def test_duplicate_weight_mapping_is_rejected(self) -> None:
         designspace = make_designspace()
@@ -123,7 +129,7 @@ class WeightMappingTest(unittest.TestCase):
             ValueError,
             "unique and strictly increase from Thin to ExtraBold",
         ):
-            _apply_designspace_weight_mapping(designspace, mapping)
+            apply_weight_mapping(designspace, mapping)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_weight_mapping.py
+++ b/scripts/tests/test_weight_mapping.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import unittest
 
 from scripts.font_ops.glyphs import _apply_designspace_weight_mapping
+
 from fontTools.designspaceLib import (
     AxisDescriptor,
     DesignSpaceDocument,

--- a/scripts/tests/test_weight_mapping.py
+++ b/scripts/tests/test_weight_mapping.py
@@ -8,7 +8,6 @@ from fontTools.designspaceLib import (
     InstanceDescriptor,
     SourceDescriptor,
 )
-
 from scripts.font_ops.glyphs import _apply_designspace_weight_mapping
 
 

--- a/scripts/tests/test_weight_mapping.py
+++ b/scripts/tests/test_weight_mapping.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import unittest
 
 from scripts.font_ops.glyphs import _apply_designspace_weight_mapping
-
 from fontTools.designspaceLib import (
     AxisDescriptor,
     DesignSpaceDocument,


### PR DESCRIPTION
## Summary

Restore the V7 behavior where pre-downloaded CJK base archives placed in the project root can be reused without downloading them again.

V8 currently only checks each CJK output directory for `*-base-static.zip` / `*-base-variable.zip`. As a result, files such as `cn-base-static.zip` and `cn-base-variable.zip` placed next to `build.py` are ignored and the build falls through to the remote download path.

This PR:

- checks the project root for local CJK base archives before the CJK output directory;
- keeps the existing output-directory archive lookup as a fallback;
- applies the same lookup behavior to both static and variable CJK base archives;
- adds regression tests verifying root archives skip the remote installation path and take precedence over output-directory copies.

The resulting lookup order is:

1. project root (`Path.cwd()`)
2. locale CJK output directory
3. remote release download
